### PR TITLE
feat: add hover comments to journal entries

### DIFF
--- a/Portfolio/src/lib/data/journal.ts
+++ b/Portfolio/src/lib/data/journal.ts
@@ -1,4 +1,20 @@
-export const JOURNAL = [
+export type JournalEntryComment = {
+  paragraph: number;
+  wordIndex: number;
+  text: string;
+};
+
+export type JournalEntryType = {
+  slug: string;
+  title: string;
+  date: string;
+  tags: readonly string[];
+  excerpt: string;
+  content: string;
+  comments?: readonly JournalEntryComment[];
+};
+
+export const JOURNAL: readonly JournalEntryType[] = [
   {
     slug: "reliable-ai-features",
     title: "Achieving a Dream Goal",
@@ -9,6 +25,13 @@ export const JOURNAL = [
     content: `
 In first year, I used to get up at 5 am for practice. The cafeteria was closed, so I would bring a mug of cheerios with me as I waited in the freezing (literally) temperatures to get picked up by my best friend and club president Ryan.
     `.trim(),
+    comments: [
+      {
+        paragraph: 0,
+        wordIndex: 2,
+        text: "I remember laughing about how cold those early mornings felt.",
+      },
+    ],
   },
   {
     slug: "good-engineering-handoff",
@@ -35,5 +58,3 @@ Warm up with a trivial repro. Hit a few simple shots. Then increase complexity.
     `.trim(),
   },
 ] as const;
-
-export type JournalEntryType = (typeof JOURNAL)[number];

--- a/Portfolio/src/pages/JournalDetail.tsx
+++ b/Portfolio/src/pages/JournalDetail.tsx
@@ -15,6 +15,13 @@ export function JournalDetail() {
     );
   }
 
+  const commentMap = new Map(
+    (entry.comments ?? []).map((comment) => [
+      `${comment.paragraph}-${comment.wordIndex}`,
+      comment,
+    ] as const),
+  );
+
   return (
     <article className="max-w-3xl">
       <Link to="/journal" className="inline-flex items-center gap-2 text-sm underline mb-4">
@@ -25,9 +32,36 @@ export function JournalDetail() {
       <div className="text-xs text-muted-foreground mt-1">{new Date(entry.date).toLocaleDateString()}</div>
 
       <div className="prose prose-sm sm:prose-base dark:prose-invert mt-6">
-        {entry.content.split("\n\n").map((p, i) => (
-          <p key={i} className="leading-7 whitespace-pre-wrap">{p}</p>
-        ))}
+        {entry.content.split("\n\n").map((paragraph, paragraphIndex) => {
+          const tokens = paragraph.split(/(\s+)/);
+          let wordCount = 0;
+
+          return (
+            <p key={paragraphIndex} className="leading-7 whitespace-pre-wrap">
+              {tokens.map((token, tokenIndex) => {
+                if (/^\s+$/.test(token) || token === "") {
+                  return <span key={`${paragraphIndex}-space-${tokenIndex}`}>{token}</span>;
+                }
+
+                const comment = commentMap.get(`${paragraphIndex}-${wordCount}`);
+                const wordKey = `${paragraphIndex}-word-${tokenIndex}`;
+                const wordElement = comment ? (
+                  <span key={wordKey} className="relative inline group">
+                    <span className="underline decoration-dotted cursor-help">{token}</span>
+                    <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-56 -translate-x-1/2 rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground opacity-0 shadow-lg transition-opacity duration-200 group-hover:opacity-100">
+                      {comment.text}
+                    </span>
+                  </span>
+                ) : (
+                  <span key={wordKey}>{token}</span>
+                );
+
+                wordCount += 1;
+                return wordElement;
+              })}
+            </p>
+          );
+        })}
       </div>
     </article>
   );


### PR DESCRIPTION
## Summary
- add support for optional word-level comments in journal data
- render journal entry content with hoverable annotations that show tooltips for commented words

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69051791ac2c8322a40de52bae09c8f8