### PR TITLE
style: refine journal annotation underline

### DIFF
--- a/Portfolio/src/index.css
+++ b/Portfolio/src/index.css
@@ -54,3 +54,106 @@ body::before {
   .dark .border { @apply border-border/40; }
   .dark .border-b { @apply border-border/40; }
 }
+
+@layer components {
+  .annotation-word {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.05em 0.2em 0.2em;
+    margin: 0 0.05em;
+    cursor: help;
+    border-radius: 9999px;
+    color: inherit;
+    text-decoration: none;
+    z-index: 0;
+    outline-offset: 3px;
+    transition: transform 160ms ease;
+  }
+
+  .annotation-word::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: 0.1em;
+    width: 82%;
+    height: 0.18em;
+    border-radius: 9999px;
+    background: linear-gradient(90deg, hsl(var(--primary) / 0.35), hsl(var(--primary) / 0.6));
+    z-index: -1;
+    opacity: 0.95;
+    transform: translateX(-50%);
+    transform-origin: center;
+    transition: width 160ms ease, height 160ms ease, filter 160ms ease;
+  }
+
+  .annotation-word:hover::after,
+  .annotation-word:focus-visible::after {
+    width: 88%;
+    height: 0.2em;
+    filter: brightness(1.08);
+  }
+
+  .annotation-word:focus-visible {
+    outline: 2px solid hsl(var(--primary) / 0.55);
+  }
+
+  .dark .annotation-word::after {
+    background: linear-gradient(90deg, hsl(var(--primary) / 0.5), hsl(var(--primary) / 0.78));
+  }
+
+  .annotation-tooltip {
+    position: absolute;
+    left: 50%;
+    top: 100%;
+    margin-top: 0.9rem;
+    width: min(18rem, 78vw);
+    transform: translate(-50%, -0.5rem) scale(0.96);
+    padding: 0.75rem 0.9rem;
+    border-radius: 0.9rem;
+    border: 1px solid hsl(var(--border) / 0.6);
+    background: linear-gradient(135deg, hsl(var(--background) / 0.95), hsl(var(--background) / 0.88));
+    color: hsl(var(--foreground));
+    font-size: 0.75rem;
+    line-height: 1.35;
+    letter-spacing: 0.01em;
+    pointer-events: none;
+    opacity: 0;
+    box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.45);
+    transition: opacity 180ms ease, transform 180ms ease;
+    backdrop-filter: blur(18px) saturate(130%);
+    z-index: 20;
+  }
+
+  .annotation-tooltip::before {
+    content: "";
+    position: absolute;
+    top: -6px;
+    left: 50%;
+    transform: translateX(-50%) rotate(45deg);
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    background: inherit;
+    border-left: 1px solid hsl(var(--border) / 0.6);
+    border-top: 1px solid hsl(var(--border) / 0.6);
+    box-shadow: 0 6px 14px -10px rgba(15, 23, 42, 0.45);
+  }
+
+  .annotation-word:hover .annotation-tooltip,
+  .annotation-word:focus-visible .annotation-tooltip {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+
+  .dark .annotation-tooltip {
+    border-color: hsl(var(--border) / 0.7);
+    background: linear-gradient(135deg, hsl(var(--secondary) / 0.35), hsl(var(--background) / 0.92));
+    box-shadow: 0 20px 44px -28px rgba(2, 6, 23, 0.7);
+  }
+
+  .dark .annotation-tooltip::before {
+    border-left-color: hsl(var(--border) / 0.7);
+    border-top-color: hsl(var(--border) / 0.7);
+  }
+}

--- a/Portfolio/src/lib/data/journal.ts
+++ b/Portfolio/src/lib/data/journal.ts
@@ -1,4 +1,20 @@
-export const JOURNAL = [
+export type JournalEntryComment = {
+  paragraph: number;
+  wordIndex: number;
+  text: string;
+};
+
+export type JournalEntryType = {
+  slug: string;
+  title: string;
+  date: string;
+  tags: readonly string[];
+  excerpt: string;
+  content: string;
+  comments?: readonly JournalEntryComment[];
+};
+
+export const JOURNAL: readonly JournalEntryType[] = [
   {
     slug: "reliable-ai-features",
     title: "Achieving a Dream Goal",
@@ -9,6 +25,13 @@ export const JOURNAL = [
     content: `
 In first year, I used to get up at 5 am for practice. The cafeteria was closed, so I would bring a mug of cheerios with me as I waited in the freezing (literally) temperatures to get picked up by my best friend and club president Ryan.
     `.trim(),
+    comments: [
+      {
+        paragraph: 0,
+        wordIndex: 2,
+        text: "I remember laughing about how cold those early mornings felt.",
+      },
+    ],
   },
   {
     slug: "good-engineering-handoff",
@@ -35,5 +58,3 @@ Warm up with a trivial repro. Hit a few simple shots. Then increase complexity.
     `.trim(),
   },
 ] as const;
-
-export type JournalEntryType = (typeof JOURNAL)[number];

--- a/Portfolio/src/pages/JournalDetail.tsx
+++ b/Portfolio/src/pages/JournalDetail.tsx
@@ -15,6 +15,13 @@ export function JournalDetail() {
     );
   }
 
+  const commentMap = new Map(
+    (entry.comments ?? []).map((comment) => [
+      `${comment.paragraph}-${comment.wordIndex}`,
+      comment,
+    ] as const),
+  );
+
   return (
     <article className="max-w-3xl">
       <Link to="/journal" className="inline-flex items-center gap-2 text-sm underline mb-4">
@@ -25,9 +32,34 @@ export function JournalDetail() {
       <div className="text-xs text-muted-foreground mt-1">{new Date(entry.date).toLocaleDateString()}</div>
 
       <div className="prose prose-sm sm:prose-base dark:prose-invert mt-6">
-        {entry.content.split("\n\n").map((p, i) => (
-          <p key={i} className="leading-7 whitespace-pre-wrap">{p}</p>
-        ))}
+        {entry.content.split("\n\n").map((paragraph, paragraphIndex) => {
+          const tokens = paragraph.split(/(\s+)/);
+          let wordCount = 0;
+
+          return (
+            <p key={paragraphIndex} className="leading-7 whitespace-pre-wrap">
+              {tokens.map((token, tokenIndex) => {
+                if (/^\s+$/.test(token) || token === "") {
+                  return <span key={`${paragraphIndex}-space-${tokenIndex}`}>{token}</span>;
+                }
+
+                const comment = commentMap.get(`${paragraphIndex}-${wordCount}`);
+                const wordKey = `${paragraphIndex}-word-${tokenIndex}`;
+                const wordElement = comment ? (
+                  <span key={wordKey} className="annotation-word" tabIndex={0}>
+                    {token}
+                    <span className="annotation-tooltip">{comment.text}</span>
+                  </span>
+                ) : (
+                  <span key={wordKey}>{token}</span>
+                );
+
+                wordCount += 1;
+                return wordElement;
+              })}
+            </p>
+          );
+        })}
       </div>
     </article>
   );


### PR DESCRIPTION
## Summary
- tighten the journal annotation wrapper spacing and reduce the highlight padding
- redraw the pseudo underline as a slimmer gradient bar to appear thinner and less wide

## Testing
- npm run build *(fails: sh: 1: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_69051791ac2c8322a40de52bae09c8f8